### PR TITLE
Prevent panic from nil request

### DIFF
--- a/blockpath.go
+++ b/blockpath.go
@@ -45,12 +45,14 @@ func New(_ context.Context, next http.Handler, config *Config, name string) (htt
 }
 
 func (b *blockPath) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	currentPath := req.URL.EscapedPath()
+	if req != nil {
+		currentPath := req.URL.EscapedPath()
 
-	for _, re := range b.regexps {
-		if re.MatchString(currentPath) {
-			rw.WriteHeader(http.StatusForbidden)
-			return
+		for _, re := range b.regexps {
+			if re.MatchString(currentPath) {
+				rw.WriteHeader(http.StatusForbidden)
+				return
+			}
 		}
 	}
 


### PR DESCRIPTION
Traefik 2.6.2 calls plugins with nil req pointer, this prevents plugin to panic. 