### PR TITLE
feat: allow matching against path with query

### DIFF
--- a/.traefik.yml
+++ b/.traefik.yml
@@ -7,4 +7,4 @@ testData:
   Regex:
     - "^/foo(.*)"
   code: 403
-  include-query: false
+  includeQuery: false

--- a/.traefik.yml
+++ b/.traefik.yml
@@ -6,3 +6,5 @@ compatibility: TODO
 testData:
   Regex:
     - "^/foo(.*)"
+  code: 403
+  include-query: false

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ configured [regular expressions](https://github.com/google/re2/wiki/Syntax).
 
 ## Dynamic
 
-To configure the `Block Path` plugin you should create a [middleware](https://docs.traefik.io/middlewares/overview/) in 
+To configure the `Block Path` plugin you should create a [middleware](https://docs.traefik.io/middlewares/overview/) in
 your dynamic configuration as explained [here](https://docs.traefik.io/middlewares/overview/). The following example creates
-and uses the `blockpath` middleware plugin to block all HTTP requests with a path starting with `/foo`. 
+and uses the `blockpath` middleware plugin to block all HTTP requests with a path starting with `/foo`.
 
 ```toml
 [http.routers]
@@ -37,6 +37,7 @@ and uses the `blockpath` middleware plugin to block all HTTP requests with a pat
   [http.middlewares.block-foo.plugin.blockpath]
     regex = ["^/foo(.*)"]
     code = 404 # optional, responds with code 404 instead of 403
+    include-query = true # optional and off by default, wether to include query in regex test
 
 [http.services]
   [http.services.my-service]

--- a/blockpath.go
+++ b/blockpath.go
@@ -12,6 +12,7 @@ import (
 type Config struct {
 	Regex []string `json:"regex,omitempty"`
 	Code  *int     `json:"code,omitempty"` // Optional: Status code to respond with, defaults to 403 Forbidden
+	IncludeQuery bool `json:"include-query,omitempty"` // Optional: Include query in regex test
 }
 
 // CreateConfig creates and initializes the plugin configuration.
@@ -24,6 +25,7 @@ type blockPath struct {
 	next    http.Handler
 	regexps []*regexp.Regexp
 	code    int
+	includeQuery bool
 }
 
 // New creates and returns a plugin instance.
@@ -49,11 +51,16 @@ func New(_ context.Context, next http.Handler, config *Config, name string) (htt
 		next:    next,
 		regexps: regexps,
 		code:    code,
+		includeQuery: config.IncludeQuery,
 	}, nil
 }
 
 func (b *blockPath) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	currentPath := req.URL.EscapedPath()
+
+	if b.includeQuery && req.URL.RawQuery != "" {
+		currentPath += "?" + req.URL.RawQuery
+	}
 
 	for _, re := range b.regexps {
 		if re.MatchString(currentPath) {

--- a/blockpath.go
+++ b/blockpath.go
@@ -10,9 +10,9 @@ import (
 
 // Config holds the plugin configuration.
 type Config struct {
-	Regex []string `json:"regex,omitempty"`
-	Code  *int     `json:"code,omitempty"` // Optional: Status code to respond with, defaults to 403 Forbidden
-	IncludeQuery bool `json:"include-query,omitempty"` // Optional: Include query in regex test
+	Regex        []string `json:"regex,omitempty"`
+	Code         *int     `json:"code,omitempty"`          // Optional: Status code to respond with, defaults to 403 Forbidden
+	IncludeQuery bool     `json:"include-query,omitempty"` // Optional: Include query in regex test
 }
 
 // CreateConfig creates and initializes the plugin configuration.
@@ -21,10 +21,10 @@ func CreateConfig() *Config {
 }
 
 type blockPath struct {
-	name    string
-	next    http.Handler
-	regexps []*regexp.Regexp
-	code    int
+	name         string
+	next         http.Handler
+	regexps      []*regexp.Regexp
+	code         int
 	includeQuery bool
 }
 
@@ -47,10 +47,10 @@ func New(_ context.Context, next http.Handler, config *Config, name string) (htt
 	}
 
 	return &blockPath{
-		name:    name,
-		next:    next,
-		regexps: regexps,
-		code:    code,
+		name:         name,
+		next:         next,
+		regexps:      regexps,
+		code:         code,
 		includeQuery: config.IncludeQuery,
 	}, nil
 }

--- a/blockpath_test.go
+++ b/blockpath_test.go
@@ -47,6 +47,7 @@ func TestServeHTTP(t *testing.T) {
 		desc          string
 		regexps       []string
 		code          *int
+		includeQuery bool
 		reqPath       string
 		expNextCall   bool
 		expStatusCode int
@@ -108,6 +109,30 @@ func TestServeHTTP(t *testing.T) {
 			expNextCall:   false,
 			expStatusCode: customCode,
 		},
+		{
+			desc:          "include query (unmatched)",
+			regexps:       []string{"^/api/woof$"},
+			includeQuery: true,
+			reqPath:       "/api/woof?rest_route=/batch/v1",
+			expNextCall:   true,
+			expStatusCode: http.StatusOK,
+		},
+		{
+			desc:          "include query (matched)",
+			regexps:       []string{".*?rest_route=/batch/v1"},
+			includeQuery: true,
+			reqPath:       "/api/woof?rest_route=/batch/v1",
+			expNextCall:   false,
+			expStatusCode: http.StatusForbidden,
+		},
+		{
+			desc:          "include query (? not included in test without params)",
+			regexps:       []string{"^/api/woof\\?"},
+			includeQuery: true,
+			reqPath:       "/api/woof?",
+			expNextCall:   true,
+			expStatusCode: http.StatusOK,
+		},
 	}
 
 	for _, test := range tests {
@@ -115,6 +140,7 @@ func TestServeHTTP(t *testing.T) {
 			cfg := &Config{
 				Regex: test.regexps,
 				Code:  test.code,
+				IncludeQuery: test.includeQuery,
 			}
 
 			nextCall := false

--- a/blockpath_test.go
+++ b/blockpath_test.go
@@ -47,7 +47,7 @@ func TestServeHTTP(t *testing.T) {
 		desc          string
 		regexps       []string
 		code          *int
-		includeQuery bool
+		includeQuery  bool
 		reqPath       string
 		expNextCall   bool
 		expStatusCode int
@@ -112,7 +112,7 @@ func TestServeHTTP(t *testing.T) {
 		{
 			desc:          "include query (unmatched)",
 			regexps:       []string{"^/api/woof$"},
-			includeQuery: true,
+			includeQuery:  true,
 			reqPath:       "/api/woof?rest_route=/batch/v1",
 			expNextCall:   true,
 			expStatusCode: http.StatusOK,
@@ -120,7 +120,7 @@ func TestServeHTTP(t *testing.T) {
 		{
 			desc:          "include query (matched)",
 			regexps:       []string{".*?rest_route=/batch/v1"},
-			includeQuery: true,
+			includeQuery:  true,
 			reqPath:       "/api/woof?rest_route=/batch/v1",
 			expNextCall:   false,
 			expStatusCode: http.StatusForbidden,
@@ -128,7 +128,7 @@ func TestServeHTTP(t *testing.T) {
 		{
 			desc:          "include query (? not included in test without params)",
 			regexps:       []string{"^/api/woof\\?"},
-			includeQuery: true,
+			includeQuery:  true,
 			reqPath:       "/api/woof?",
 			expNextCall:   true,
 			expStatusCode: http.StatusOK,
@@ -138,8 +138,8 @@ func TestServeHTTP(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			cfg := &Config{
-				Regex: test.regexps,
-				Code:  test.code,
+				Regex:        test.regexps,
+				Code:         test.code,
 				IncludeQuery: test.includeQuery,
 			}
 


### PR DESCRIPTION
I wanted to configure my traefik instance for mitigating wp2shell on multiple wordpress instances at once, but I needed query matching for that.

Did not test this in production yet... 

(edit) it works :)